### PR TITLE
Atomic debugger/deps

### DIFF
--- a/atomMock.js
+++ b/atomMock.js
@@ -1,115 +1,44 @@
 const one = {
   statusAtom: {
-    r: 1,
-    nodeDeps: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
-    contents: 'Next player: X',
+    reference: 1,
+    dependencies: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
+    dependants: [],
+    value: 'Next player: X',
   },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
+  resetSquaresAtom: {
+    reference: 0,
+    dependencies: ['resetSquaresAtom'],
+    dependants: ['resetSquaresAtom'],
+    value: null,
+  },
   selectSquareAtom: {
-    r: 1,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, null, null, null, null, null, null, null],
+    reference: 1,
+    dependencies: ['squaresAtom'],
+    dependants: [],
+    value: [null, null, null, null, null, null, null, null, null],
   },
-  winnerAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: null },
+  winnerAtom: {
+    reference: 1,
+    dependencies: ['squaresAtom'],
+    dependants: ['statusAtom'],
+    value: null,
+  },
   squaresAtom: {
-    r: 0,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, null, null, null, null, null, null, null],
+    reference: 0,
+    dependencies: ['squaresAtom'],
+    dependants: [
+      'squaresAtom',
+      'winnerAtom',
+      'nextValueAtom',
+      'statusAtom',
+      'selectSquareAtom',
+    ],
+    value: [null, null, null, null, null, null, null, null, null],
   },
-  nextValueAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: 'X' },
-};
-const two = {
-  statusAtom: {
-    r: 2,
-    nodeDeps: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
-    contents: 'Next player: O',
-  },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
-  selectSquareAtom: {
-    r: 2,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, null, null, 'X', null, null, null, null],
-  },
-  winnerAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: null },
-  squaresAtom: {
-    r: 1,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, null, null, 'X', null, null, null, null],
-  },
-  nextValueAtom: { r: 2, nodeDeps: ['squaresAtom'], contents: 'O' },
-};
-const three = {
-  statusAtom: {
-    r: 3,
-    nodeDeps: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
-    contents: 'Next player: X',
-  },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
-  selectSquareAtom: {
-    r: 3,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, 'O', null, 'X', null, null, null, null],
-  },
-  winnerAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: null },
-  squaresAtom: {
-    r: 2,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, 'O', null, 'X', null, null, null, null],
-  },
-  nextValueAtom: { r: 3, nodeDeps: ['squaresAtom'], contents: 'X' },
-};
-const four = {
-  statusAtom: {
-    r: 4,
-    nodeDeps: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
-    contents: 'Next player: O',
-  },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
-  selectSquareAtom: {
-    r: 4,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, 'O', null, 'X', 'X', null, null, null],
-  },
-  winnerAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: null },
-  squaresAtom: {
-    r: 3,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, null, 'O', null, 'X', 'X', null, null, null],
-  },
-  nextValueAtom: { r: 4, nodeDeps: ['squaresAtom'], contents: 'O' },
-};
-const five = {
-  statusAtom: {
-    r: 5,
-    nodeDeps: ['winnerAtom', 'squaresAtom', 'nextValueAtom'],
-    contents: 'Next player: X',
-  },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
-  selectSquareAtom: {
-    r: 5,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, 'O', 'O', null, 'X', 'X', null, null, null],
-  },
-  winnerAtom: { r: 1, nodeDeps: ['squaresAtom'], contents: null },
-  squaresAtom: {
-    r: 4,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, 'O', 'O', null, 'X', 'X', null, null, null],
-  },
-  nextValueAtom: { r: 5, nodeDeps: ['squaresAtom'], contents: 'X' },
-};
-const six = {
-  statusAtom: { r: 6, nodeDeps: ['winnerAtom'], contents: 'Winner: X' },
-  resetSquaresAtom: { r: 0, nodeDeps: ['resetSquaresAtom'], contents: null },
-  selectSquareAtom: {
-    r: 6,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, 'O', 'O', 'X', 'X', 'X', null, null, null],
-  },
-  winnerAtom: { r: 2, nodeDeps: ['squaresAtom'], contents: 'X' },
-  squaresAtom: {
-    r: 5,
-    nodeDeps: ['squaresAtom'],
-    contents: [null, 'O', 'O', 'X', 'X', 'X', null, null, null],
-  },
+  nextValueAtom: {
+    reference: 1,
+    dependencies: ['squaresAtom'],
+    dependants: ['statusAtom'],
+    value: 'X',
+  },;
 };

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-devtools",
-  "version": "1.0.90",
+  "version": "1.0.96",
   "description": "Library to connect your Jotai application to Atomic Devtools Extension",
   "main": "dist/module/index.js",
   "files": [
@@ -14,7 +14,7 @@
     "patch:publish": "npm version patch && npm publish"
   },
   "peerDependencies": {
-    "jotai": "^0.15.3",
+    "jotai": "^0.16.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-devtools",
-  "version": "1.0.77",
+  "version": "1.0.90",
   "description": "Library to connect your Jotai application to Atomic Devtools Extension",
   "main": "dist/module/index.js",
   "files": [

--- a/package/src/index.jsx
+++ b/package/src/index.jsx
@@ -11,167 +11,149 @@ const AtomStateContext = createContext({});
 const AtomUpdateContext = createContext('test');
 
 // eslint-disable-next-line react/prop-types
+
 function AtomicDebugger({ children }) {
-  //declaring state to build serializable atomState to send to devtool
-  //setAtomState is consumed by our useAtom() wrapper useAtomicDevtools()
+  //Declaring state to build serializable atomState to send to devtool
+  //SetAtomState is consumed by our useAtom() wrapper useAtomicDevtools()
   const [usedAtoms, setUsedAtoms] = useState({});
 
-  //for checking that there are changes to state before sending messages to Devtool
+  //State for Checking that there are changes to state before sending messages to Devtool.
   const [previousState, setPreviousState] = useState(null);
 
-  // get rootFiber from within debugger component
+  //Get rootFiber from within debugger component.
   const fiberRoot = document.getElementById('root')._reactRootContainer
     ._internalRoot.current.stateNode.current;
 
-  console.log('fiberRoot --->', fiberRoot);
-
-  //chrome storage??
+  //? Send fiber to chrome.storage here?
 
   let jotaiProviderComponentStoreContext;
 
-  //Skip first react render cycle
+  //Skip first react render cycle.
   if (fiberRoot.child) {
     jotaiProviderComponentStoreContext =
       fiberRoot.child.child.memoizedState.memoizedState.current;
 
-    console.log(
-      'jotaiProviderComponentStoreContext ---> ',
-      jotaiProviderComponentStoreContext
-    );
-    //Assume <Provider> Component is top level rendered in <App>
-    //Make sure jotai provider is there.
-    //figure out providerless mode
+    //?Assume <Provider> Component is top level rendered in <App>?
+    //TODO Make sure jotai provider is there.
+    //TODO figure out provider-less mode.
 
-    //investigate when and if we need useEffect to avoid update warnings with rendering
-    // useEffect(() => {
-    //}, []);
-
-    // TODO connect to dev tool to notify for state changes
-
+    //Store Jotai state from provider context.
     const jotaiState = jotaiProviderComponentStoreContext[0];
-    console.log('jotaiState ---> ', jotaiState);
+    // console.log('jotaiState ---> ', jotaiState);
 
-    //get key Symbols for mutable source
+    //Get key Symbols for mutable source.
     const stateSymbolKeys = Object.getOwnPropertySymbols(jotaiState);
-    console.log('stateSymbolKeys ---> ', stateSymbolKeys);
+    // console.log('stateSymbolKeys ---> ', stateSymbolKeys);
 
-    //get first symbol for Provider state in mutable source
+    //Get first symbol for Provider state in mutable source.
     const stateSymbol = stateSymbolKeys[0];
-    console.log('stateSymbol ---> ', stateSymbol);
+    // console.log('stateSymbol ---> ', stateSymbol);
 
-    //Get state from mutable source
+    //Get state from mutable source.
     const state = jotaiState[stateSymbol];
-    console.log('state ---> ', state);
+    // console.log('state ---> ', state);
 
-    //mutable source holds 'a' which is atomState and 'm' which is mountedState
-    //get atomState from Provider state
-    const atomState = state.a;
-    console.log('atomState ---> ', atomState);
+    //Mutable source has keys 'a', which is atomStateMap and 'm', which is mountedMap.
+    //https://github.com/pmndrs/jotai/blob/537d5b15ec3d7c0293db720c4007158fb32dec6f/src/core/vanilla.ts#L52-L58
 
-    //get mountedState from Provider state
-    const mountedState = state.m;
-    console.log('mountedState ---> ', mountedState);
+    //Get atomStateMap from Provider state.
+    const atomStateMap = state.a;
+    // console.log('atomStateMap ---> ', atomStateMap);
 
-    const mountedStateToGetDependants = {};
+    //Get mountedMap from Provider state.
+    const mountedMap = state.m;
+    // console.log('mountedMap ---> ', mountedMap);
 
-    //Create a serializable object of atom state to send to devtool
+    //Declare a store for mounted states per atom.
+    const mountedStates = {};
+
+    //Create a serializable object of atom state to send to devtool.
     const atomsToDevtool = {};
 
-    //Iterating through atate of Atoms acculated through applications use of useAtomicDevtool() and atomic()
-    //in order to aquire the atomState of each atom from WeakMap
+    //Iterating through Atoms accumulated in debugging application's use of useAtomicDevtool().
+    //in order to acquire the atomState of each atom from atomStateMap (WeakMap).
+    //https://github.com/pmndrs/jotai/blob/537d5b15ec3d7c0293db720c4007158fb32dec6f/src/core/vanilla.ts#L23-L31
     for (const [label, atom] of Object.entries(usedAtoms)) {
-      //Create copy of atom state per atom in Provider state
-      atomsToDevtool[label] = { ...atomState.get(atom) };
+      atomsToDevtool[label] = { ...atomStateMap.get(atom) };
+      mountedStates[label] = { ...mountedMap.get(atom) };
     }
 
-    //travers deps in atomsToDevtools and find missing atoms (global)
-    const traverseDeps = (label, atom) => {
+    //
+    /**
+     * Recursively transverse readDependencies per atom atomsToDevtools and find missing atoms (declared outside of React Components).
+     * Recursively transverse dependents in mountedStates to find missing atoms (declared outside of React components).
+     * Acquire atomState and mountedState with found atoms.
+     * @param {*} atom dependent or readDependency atom
+     * @param {*} mapType string trigger to delegate which map to get the state, 'atomState' or 'mounted'
+     */
+    const traverseDeps = (atom, mapType) => {
       atom.d.forEach((ref, dep) => {
-        let dependantAtom = atomsToDevtool[dep.debugLabel || dep.toString()];
-        if (!dependantAtom) {
-          dependantAtom = {
-            ...atomState.get(dep),
-          };
+        let label = dep.debugLabel || dep.toString();
+        let readDependency = null;
+        let dependent = null;
 
-          atomsToDevtool[dep.debugLabel || dep.toString()] = dependantAtom;
-          label = dep.debugLabel || dep.toString();
+        if (mapType === 'atomState') readDependency = atomsToDevtool[label];
+        else if (mapType === 'mounted') dependent = mountedStates[label];
 
-          traverseDeps(label, dependantAtom);
+        if (readDependency === undefined || dependent === undefined) {
+          if (mapType === 'atomState') {
+            //
+            readDependency = {
+              ...atomStateMap.get(dep),
+            };
+            atomsToDevtool[label] = readDependency;
+            traverseDeps(readDependency, mapType);
+          }
+
+          if (mapType === 'mounted') {
+            dependent = {
+              ...mountedMap.get(dep),
+            };
+            mountedStates[label] = dependent;
+            traverseDeps(dependent, mapType);
+          }
         }
       });
     };
 
-    for (const [label, atom] of Object.entries(atomsToDevtool)) {
-      traverseDeps(label, atom);
+    //Initialize recursive algorithm to find atoms for each atom initially stored in atomsToDevtools.
+    for (const [_, atom] of Object.entries(atomsToDevtool)) {
+      traverseDeps(atom, 'atomState');
+      traverseDeps(atom, 'mounted');
     }
 
-    // iterate over Map of atom dependancies and push label to array
-    // console.log('atomsToDevtool --- > ', atomsToDevtool);
-    console.log(
-      'mountedStateToGetDependants ---> ',
-      mountedStateToGetDependants
-    );
-
-    for (const [label, atom] of Object.entries(usedAtoms)) {
-      console.log('label ---> ', label);
-      console.log('atom ---> ', atom);
-
-      mountedStateToGetDependants[label] = { ...mountedState.get(atom) };
-    }
-
-    const traverseMountedDeps = (label, atom) => {
-      atom.d.forEach((ref, dep) => {
-        let dependantAtom =
-          mountedStateToGetDependants[dep.debugLabel || dep.toString()];
-        if (!dependantAtom) {
-          dependantAtom = {
-            ...mountedState.get(dep),
-          };
-
-          mountedStateToGetDependants[
-            dep.debugLabel || dep.toString()
-          ] = dependantAtom;
-          label = dep.debugLabel || dep.toString();
-
-          traverseMountedDeps(label, dependantAtom);
-        }
-      });
-    };
-
+    //Serialize dependencies (read & mounted) per atom in atomsToDevtool for messaging.
     for (const [label, atom] of Object.entries(atomsToDevtool)) {
-      traverseMountedDeps(label, atom);
-    }
+      //Array of atom dependant labels
+      const mountedDeps = [];
 
-    for (const [label, atom] of Object.entries(atomsToDevtool)) {
-      let mountedDeps = [];
-
-      mountedStateToGetDependants[label]?.d.forEach(atom => {
+      mountedStates[label].d.forEach(atom => {
         mountedDeps.push(atom.debugLabel || atom.toString());
       });
 
-      //Array of atom dependancy labels
+      //Array of atom readDependency labels
       const atomDeps = [];
 
       atom.d.forEach((ref, dep) => {
         atomDeps.push(dep.debugLabel || dep.toString());
       });
 
-      //replace Map reference with serializable array of dependecies
-      atom.d = atomDeps;
-
+      //Formatted serializable object that is sent to devtool.
       atomsToDevtool[label] = {
         reference: atom.r,
-        dependencies: atom.d,
-        dependants: mountedDeps,
+        readDependencies: atomDeps,
+        dependents: mountedDeps,
         value: atom.v,
       };
     }
 
+    //Serialize state to send to devtool.
     const atomsToDevtoolString = JSON.stringify(atomsToDevtool);
-    console.log('atomsToDevtoolString --- > ', atomsToDevtoolString);
+
+    //TODO add try/catch for if devtool is installed and error messaging to client
+    //TODO redeclare action types for messaging
 
     let extension;
-
     extension = window.__ATOMIC_DEVTOOLS_EXTENSION__;
 
     if (previousState !== atomsToDevtoolString) {
@@ -195,46 +177,28 @@ function AtomicDebugger({ children }) {
 }
 
 function useAtomicDevtool(atom, label) {
-  //Use context provided by AtomicDebugger component to retrieve setAtomState()
+  //Use context provided by AtomicDebugger component to retrieve setAtomState().
   const setUsedAtoms = useContext(AtomUpdateContext);
 
-  //Update AtomicDebugger AtomState with a shallow copy of the atom used in application component.
+  //Update AtomicDebugger usedAtoms with a shallow copy of the atom used in application component.
   setUsedAtoms(atomState => {
     const copy = { ...atomState };
     copy[label] = atom;
     return { ...copy };
 
-    // Why doesn't this retain value??
-    // atomState[label] = atom;
-    // return atomState
+    //?Why doesn't this retain value??
+    //atomState[label] = atom;
+    //return atomState
   });
 
-  //Set debug label key for natual language reference (Jotai uses 'atom + incremented value for labels internally)
+  //Set debug label key for natural language reference (Jotai uses 'atom + incremented value' for labels internally)
   atom.debugLabel = label;
 
   //for React Devtools...
   useDebugValue(atom, () => label);
 
-  // useEffect(() => {
-  let extension;
-
-  extension = window.__ATOMIC_DEVTOOLS_EXTENSION__;
-
-  try {
-    // extension.sendMessageToContentScripts({
-    //   action: 'TEST_FROM_WRAPPER',
-    //   payload: 'from wrapper',
-    // });
-  } catch {}
-  // }, [atom]);
-
-  //return useAtom to maintain functionality
+  //Return the value of useAtom invoked to maintain functionality in Jotai application.
   return useAtom(atom);
 }
 
-export {
-  AtomicDebugger,
-  AtomStateContext,
-  AtomUpdateContext,
-  useAtomicDevtool,
-};
+export { AtomicDebugger, useAtomicDevtool };

--- a/src/app/components/AtomNetwork/AtomToDependentNetwork.tsx
+++ b/src/app/components/AtomNetwork/AtomToDependentNetwork.tsx
@@ -51,7 +51,7 @@ function AtomToDependentNetwork({
 
     atomDependentData.nodeDeps = [];
 
-    object.dependencies.map(item => {
+    object.readDependencies.map(item => {
       atomDependentData.nodeDeps.push({ name: item });
     });
 

--- a/src/app/components/AtomNetwork/AtomToDependentNetwork.tsx
+++ b/src/app/components/AtomNetwork/AtomToDependentNetwork.tsx
@@ -37,7 +37,7 @@ function AtomToDependentNetwork({
   const atomNamesArray = Object.keys(snapshotHistory[snapshotIndex]);
 
   function AtomToDependents(atom: string | undefined) {
-    let atomDependentData: any = {};
+    const atomDependentData: any = {};
     let object: snapshot;
 
     if (!atom) return;
@@ -51,7 +51,7 @@ function AtomToDependentNetwork({
 
     atomDependentData.nodeDeps = [];
 
-    object.d.map(item => {
+    object.dependencies.map(item => {
       atomDependentData.nodeDeps.push({ name: item });
     });
 
@@ -146,7 +146,7 @@ function AtomToDependentNetwork({
                         left = radialX;
 
                         const radiusFunc = (name: string) => {
-                          let nodeLength = name.length;
+                          const nodeLength = name.length;
                           if (nodeLength < 5) return nodeLength + 20;
                           if (nodeLength < 10) return nodeLength + 25;
                           if (nodeLength < 15) return nodeLength + 40;

--- a/src/app/components/ComponentGraph/ComponentGraph.tsx
+++ b/src/app/components/ComponentGraph/ComponentGraph.tsx
@@ -209,7 +209,7 @@ function ComponentGraph({
 
                       {tree.descendants().map((node, key) => {
                         const widthFunc = (name: string) => {
-                          let nodeLength = name.length;
+                          const nodeLength = name.length;
                           if (nodeLength < 5) return nodeLength + 30;
                           if (nodeLength < 10) return nodeLength + 50;
                           if (nodeLength < 15) return nodeLength + 100;
@@ -368,7 +368,7 @@ function ComponentGraph({
               <br />
               -Value: {JSON.stringify(tooltipData.state[item].values)}
               <br />
-              -Dependents:{' '}
+              -Dependencies:{' '}
               {JSON.stringify(tooltipData.state[item].dependencies)}
             </div>
           ))}

--- a/src/extension/content-script.ts
+++ b/src/extension/content-script.ts
@@ -49,7 +49,7 @@ injectCode(
   `${initHook}
   ;(function testINJECT(target) {target.__ATOMIC_DEVTOOLS_EXTENSION__.test = "test"})(window)
   ;(${fiberHelper.toString()}(window));
-  debugger;
+  // debugger;
   `
 );
 // injectCode(chrome.runtime.getURL('bundles/backend.bundle.js'));


### PR DESCRIPTION
# Checklist
- [ ] Bugfix
- [X] New feature
- [ ] Refactor

# Related Issue
- Previously AtomicDebugger Component only acquired atom "readDependencies" from Jotai's Provider atomStateMap. Needed to also get atom "dependents" from mountedMap also. 

# Solution
- Extended existing recursive function to also iterate over mountedMap to get mounted dependents from Jotai Provider Context. 

# Additional Info
- Cleaned package index.js. Added notation.
- This pull affects App.js in devtool components, changing labels to match data sent from AtomicDebugger.

